### PR TITLE
Upgrade codebase to 1.0 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ Basically it sync whatever entity component you want with GPU data to perform in
 [assembly: InstancedPropertyComponent(typeof(SpriteColor), "_color", PropertyFormat.Float4)]
 ```
 ```csharp
-// registrate render with ID, Material, capacity data and set of properties
-var renderSystem = World.GetSystem<SpriteRenderingSystem>();
+// registrate render with ID, Material, capacity data and set of proaperties
+if (!SystemAPI.ManagedAPI.TryGetSingleton<RenderArchetypeStorage>(out var renderArchetypeStorage))
+    return;
 // don't registrate same renderID
-renderSystem.RegisterRender
+renderArchetypeStorage.RegisterRender
 (
     renderID,
     material,   // material with [Enable GPU Instancing] enabled and shader supporting instancing

--- a/Rendering/Common/NSprites.cs
+++ b/Rendering/Common/NSprites.cs
@@ -4,6 +4,8 @@ using UnityEngine;
 using System.Reflection;
 using Unity.Entities;
 using System.Runtime.CompilerServices;
+using System.Linq;
+using Unity.Collections;
 
 namespace NSprites
 {
@@ -197,6 +199,18 @@ namespace NSprites
 #endif
 #endif
             return mode;
+        }
+
+        /// <summary>Returns array with all default components for rendering entities including types marked with <see cref="DisableRenderingComponent"/> attribute</summary>
+        /// [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static NativeArray<ComponentType> GetDefaultComponentTypes(in Allocator allocator = Allocator.Temp)
+        {
+            var disableRenderingComponentTypes = new NativeArray<ComponentType>(DisableRenderingComponent.GetTypes().ToArray(), Allocator.Temp);
+            var defaultComponents = new NativeArray<ComponentType>(disableRenderingComponentTypes.Length + 1, allocator);
+            NativeArray<ComponentType>.Copy(disableRenderingComponentTypes, 0, defaultComponents, 0, disableRenderingComponentTypes.Length);
+            defaultComponents[^1] = ComponentType.ReadOnly<SpriteRenderID>();
+            disableRenderingComponentTypes.Dispose();
+            return defaultComponents;
         }
     }
 }

--- a/Rendering/Components/RenderArchetypeStorage.cs
+++ b/Rendering/Components/RenderArchetypeStorage.cs
@@ -8,17 +8,17 @@ namespace NSprites
     public class RenderArchetypeStorage : IComponentData
     {
         /// <summary><see cref="Mesh"/> We will use to render every sprite, which can be created once in system</summary>
-        internal Mesh _quad = NSpritesUtils.ConstructQuad();
+        internal Mesh Quad = NSpritesUtils.ConstructQuad();
         /// <summary>Shader property's id to property data map</summary>
-        internal readonly Dictionary<int, PropertyInternalData> _propetyMap = new();
+        internal readonly Dictionary<int, PropertyInternalData> PropertyMap = new();
         /// <summary>All whenever registered render archetypes. Each registred archetype will be updated every frame no matter if there is any entities.</summary>
-        internal readonly List<RenderArchetype> _renderArchetypes = new();
+        internal readonly List<RenderArchetype> RenderArchetypes = new();
         /// <summary>System's state with all necessary data to pass to <see cref="RenderArchetype"/> to update</summary>
-        internal SystemState _state;
+        internal SystemData SystemData;
 
         internal void Dispose()
         {
-            foreach (var archetype in _renderArchetypes)
+            foreach (var archetype in RenderArchetypes)
                 archetype.Dispose();
         }
         internal void Initialize() => GatherPropertiesTypes();
@@ -28,7 +28,7 @@ namespace NSprites
         /// But you can use this method to manually pass bind data.
         /// </summary>
         public void BindComponentToShaderProperty(in int propertyID, Type componentType, in PropertyFormat format)
-            => _propetyMap.Add(propertyID, new PropertyInternalData(new ComponentType(componentType, ComponentType.AccessMode.ReadOnly), format));
+            => PropertyMap.Add(propertyID, new PropertyInternalData(new ComponentType(componentType, ComponentType.AccessMode.ReadOnly), format));
         /// <summary>
         /// Binds component to shader's property. Binded components will be gathered from entities during render process to be passed to shader.
         /// By default system will automatically gather and bind all component types which have <see cref="InstancedPropertyComponent"/> attribute to specified property.
@@ -37,7 +37,7 @@ namespace NSprites
         public void BindComponentToShaderProperty(in string propertyName, Type componentType, in PropertyFormat format)
             => BindComponentToShaderProperty(Shader.PropertyToID(propertyName), componentType, format);
 
-        /// <summary>Fills <see cref="_propetyMap"/> with data of all types marked by <see cref="InstancedPropertyComponent"/> attribute</summary>
+        /// <summary>Fills <see cref="PropertyMap"/> with data of all types marked by <see cref="InstancedPropertyComponent"/> attribute</summary>
         private void GatherPropertiesTypes()
         {
             foreach (var property in InstancedPropertyComponent.GetProperties())
@@ -57,6 +57,6 @@ namespace NSprites
         /// <param name="initialCapacity">compute buffers intial capacity.</param>
         /// <param name="capacityStep">compute buffers capacity increase step when the current limit on the number of entities is exceeded.</param>
         public void RegisterRender(in int id, Material material, MaterialPropertyBlock materialPropertyBlock = null, in int initialCapacity = 1, in int capacityStep = 1, params PropertyData[] propertyDataSet)
-            => _renderArchetypes.Add(new RenderArchetype(material, propertyDataSet, _propetyMap, id, _state.system, materialPropertyBlock, initialCapacity, capacityStep));
+            => RenderArchetypes.Add(new RenderArchetype(material, propertyDataSet, PropertyMap, id, materialPropertyBlock, initialCapacity, capacityStep));
     }
 }

--- a/Rendering/Components/RenderArchetypeStorage.cs
+++ b/Rendering/Components/RenderArchetypeStorage.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using Unity.Entities;
+using UnityEngine;
+
+namespace NSprites
+{
+    public class RenderArchetypeStorage : IComponentData
+    {
+        /// <summary><see cref="Mesh"/> We will use to render every sprite, which can be created once in system</summary>
+        internal Mesh _quad = NSpritesUtils.ConstructQuad();
+        /// <summary>Shader property's id to property data map</summary>
+        internal readonly Dictionary<int, PropertyInternalData> _propetyMap = new();
+        /// <summary>All whenever registered render archetypes. Each registred archetype will be updated every frame no matter if there is any entities.</summary>
+        internal readonly List<RenderArchetype> _renderArchetypes = new();
+        /// <summary>System's state with all necessary data to pass to <see cref="RenderArchetype"/> to update</summary>
+        internal SystemState _state;
+
+        internal void Dispose()
+        {
+            foreach (var archetype in _renderArchetypes)
+                archetype.Dispose();
+        }
+        internal void Initialize() => GatherPropertiesTypes();
+        /// <summary>
+        /// Binds component to shader's property. Binded components will be gathered from entities during render process to be passed to shader.
+        /// By default system will automatically gather and bind all component types which have <see cref="InstancedPropertyComponent"/> attribute to specified property.
+        /// But you can use this method to manually pass bind data.
+        /// </summary>
+        public void BindComponentToShaderProperty(in int propertyID, Type componentType, in PropertyFormat format)
+            => _propetyMap.Add(propertyID, new PropertyInternalData(new ComponentType(componentType, ComponentType.AccessMode.ReadOnly), format));
+        /// <summary>
+        /// Binds component to shader's property. Binded components will be gathered from entities during render process to be passed to shader.
+        /// By default system will automatically gather and bind all component types which have <see cref="InstancedPropertyComponent"/> attribute to specified property.
+        /// But you can use this method to manually pass bind data.
+        /// </summary>
+        public void BindComponentToShaderProperty(in string propertyName, Type componentType, in PropertyFormat format)
+            => BindComponentToShaderProperty(Shader.PropertyToID(propertyName), componentType, format);
+
+        /// <summary>Fills <see cref="_propetyMap"/> with data of all types marked by <see cref="InstancedPropertyComponent"/> attribute</summary>
+        private void GatherPropertiesTypes()
+        {
+            foreach (var property in InstancedPropertyComponent.GetProperties())
+                BindComponentToShaderProperty(property.propertyName, property.componentType, property.format);
+        }
+
+        /// <summary>
+        /// Registrate render, which is combination of Material + set of StrcutredBuffer property names in shader.
+        /// Every entity with <see cref="SpriteRenderID"/> component with ID value equal to passed ID, will be rendered by registered render.
+        /// Entity without instanced property component from passed properties will be rendered with uninitialized values (please, initialize entities carefully, because render with uninitialized values can lead to strange visual results).
+        /// Though you can use <b><see cref="NSPRITES_PROPERTY_FALLBACK_ENABLE"/></b> directive to enable fallback values, so any chunk without property component will pass default values.
+        /// </summary>
+        /// <param name="id">ID of <see cref="SpriteRenderID.id"/>. All entities with the same SCD will be updated by registering render archetype. Client should manage uniqueness (or not) of ids by himself.</param>
+        /// <param name="material"><see cref="Material"/> wich will be used to render sprites.</param>
+        /// <param name="materialPropertyBlock"><see cref="MaterialPropertyBlock"/> you can pass if you want to do some extra overriding by yourself.</param>
+        /// <param name="propertyDataSet">IDs of StructuredBuffer properties in shader AND <see cref="PropertyUpdateMode"/> for each property.</param>
+        /// <param name="initialCapacity">compute buffers intial capacity.</param>
+        /// <param name="capacityStep">compute buffers capacity increase step when the current limit on the number of entities is exceeded.</param>
+        public void RegisterRender(in int id, Material material, MaterialPropertyBlock materialPropertyBlock = null, in int initialCapacity = 1, in int capacityStep = 1, params PropertyData[] propertyDataSet)
+            => _renderArchetypes.Add(new RenderArchetype(material, propertyDataSet, _propetyMap, id, _state.system, materialPropertyBlock, initialCapacity, capacityStep));
+    }
+}

--- a/Rendering/Components/RenderArchetypeStorage.cs.meta
+++ b/Rendering/Components/RenderArchetypeStorage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 64386a9a78d282249a07927958af6573
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Rendering/Systems/SpriteRenderingSystem.cs
+++ b/Rendering/Systems/SpriteRenderingSystem.cs
@@ -10,64 +10,56 @@ namespace NSprites
     /// </summary>
     [WorldSystemFilter(WorldSystemFilterFlags.Default | WorldSystemFilterFlags.Editor)]
     [UpdateInGroup(typeof(PresentationSystemGroup))]
-    public partial class SpriteRenderingSystem : SystemBase
+    public partial struct SpriteRenderingSystem : ISystem
     {
-        protected override void OnCreate()
+        public void OnCreate(ref SystemState state)
         {
 #if NSPRITES_REACTIVE_DISABLE && NSPRITES_STATIC_DISABLE && NSPRITES_EACH_UPDATE_DISABLE
             throw new Exception($"You can't disable Reactive, Static and Each-Update properties modes at the same time, there should be at least one mode if you want system to work. Please, enable at least one mode.");
 #endif
-            base.OnCreate();
-
-            var renderArchetypeStorage = new RenderArchetypeStorage
-            {
-                _state = new SystemState
-                {
-                    system = this,
-                    query = GetEntityQuery(NSpritesUtils.GetDefaultComponentTypes())
-                }
-            };
+            // instansiate and initialize system data
+            var renderArchetypeStorage = new RenderArchetypeStorage{ SystemData = new SystemData { query = state.GetEntityQuery(NSpritesUtils.GetDefaultComponentTypes()) }};
             renderArchetypeStorage.Initialize();
+            state.EntityManager.AddComponentObject(state.SystemHandle, renderArchetypeStorage);
+        }
 
-            EntityManager.AddComponentObject(SystemHandle, renderArchetypeStorage);
-        }
-        protected override void OnDestroy()
+        public void OnDestroy(ref SystemState state)
         {
-            base.OnDestroy();
-            EntityManager.GetComponentObject<RenderArchetypeStorage>(SystemHandle).Dispose();
+            SystemAPI.ManagedAPI.GetComponent<RenderArchetypeStorage>(state.SystemHandle).Dispose();
         }
-        protected override void OnUpdate()
+
+        public void OnUpdate(ref SystemState state)
         {
-            var renderArchetypeStorage = SystemAPI.ManagedAPI.GetComponent<RenderArchetypeStorage>(SystemHandle);
+            var renderArchetypeStorage = SystemAPI.ManagedAPI.GetComponent<RenderArchetypeStorage>(state.SystemHandle);
 #if UNITY_EDITOR
-            if (!Application.isPlaying && renderArchetypeStorage._quad == null)
-                renderArchetypeStorage._quad = NSpritesUtils.ConstructQuad();
+            if (!Application.isPlaying && renderArchetypeStorage.Quad == null)
+                renderArchetypeStorage.Quad = NSpritesUtils.ConstructQuad();
 #endif
             // update state to pass to render archetypes
 #if !NSPRITES_REACTIVE_DISABLE || !NSPRITES_STATIC_DISABLE
-            var state = renderArchetypeStorage._state;
-            state.lastSystemVersion = LastSystemVersion;
-            state.propertyPointer_CTH_RW = SystemAPI.GetComponentTypeHandle<PropertyPointer>(false);
-            state.propertyPointerChunk_CTH_RW = SystemAPI.GetComponentTypeHandle<PropertyPointerChunk>(false);
-            state.propertyPointerChunk_CTH_RO = SystemAPI.GetComponentTypeHandle<PropertyPointerChunk>(true);
+            var systemData = renderArchetypeStorage.SystemData;
+            systemData.lastSystemVersion = state.LastSystemVersion;
+            systemData.propertyPointer_CTH_RW = SystemAPI.GetComponentTypeHandle<PropertyPointer>(false);
+            systemData.propertyPointerChunk_CTH_RW = SystemAPI.GetComponentTypeHandle<PropertyPointerChunk>(false);
+            systemData.propertyPointerChunk_CTH_RO = SystemAPI.GetComponentTypeHandle<PropertyPointerChunk>(true);
 #endif
-            state.inputDeps = Dependency;
+            systemData.inputDeps = state.Dependency;
 
             // schedule render archetype's properties data update
-            var renderArchetypeHandles = new NativeArray<JobHandle>(renderArchetypeStorage._renderArchetypes.Count, Allocator.Temp);
-            for (int archetypeIndex = 0; archetypeIndex < renderArchetypeStorage._renderArchetypes.Count; archetypeIndex++)
-                renderArchetypeHandles[archetypeIndex] = renderArchetypeStorage._renderArchetypes[archetypeIndex].ScheduleUpdate(state);
+            var renderArchetypeHandles = new NativeArray<JobHandle>(renderArchetypeStorage.RenderArchetypes.Count, Allocator.Temp);
+            for (int archetypeIndex = 0; archetypeIndex < renderArchetypeStorage.RenderArchetypes.Count; archetypeIndex++)
+                renderArchetypeHandles[archetypeIndex] = renderArchetypeStorage.RenderArchetypes[archetypeIndex].ScheduleUpdate(systemData, ref state);
 
             // force complete properties data update and draw archetypes
-            for (int archetypeIndex = 0; archetypeIndex < renderArchetypeStorage._renderArchetypes.Count; archetypeIndex++)
+            for (int archetypeIndex = 0; archetypeIndex < renderArchetypeStorage.RenderArchetypes.Count; archetypeIndex++)
             {
-                var archetype = renderArchetypeStorage._renderArchetypes[archetypeIndex];
+                var archetype = renderArchetypeStorage.RenderArchetypes[archetypeIndex];
                 archetype.CompleteUpdate();
-                archetype.Draw(renderArchetypeStorage._quad, new Bounds(new Vector3(0f, 0f, archetypeIndex), Vector3.one * 1000f));
+                archetype.Draw(renderArchetypeStorage.Quad, new Bounds(new Vector3(0f, 0f, archetypeIndex), Vector3.one * 1000f));
             }
 
             // combine handles from all render archetypes we have updated
-            Dependency = JobHandle.CombineDependencies(renderArchetypeHandles);
+            state.Dependency = JobHandle.CombineDependencies(renderArchetypeHandles);
         }
     }
 }

--- a/Rendering/Systems/SpriteRenderingSystem.cs
+++ b/Rendering/Systems/SpriteRenderingSystem.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Unity.Collections;
 using Unity.Entities;
 using Unity.Jobs;
@@ -25,7 +24,7 @@ namespace NSprites
                 _state = new SystemState
                 {
                     system = this,
-                    query = GetEntityQuery(GetDefaultComponentTypes())
+                    query = GetEntityQuery(NSpritesUtils.GetDefaultComponentTypes())
                 }
             };
             renderArchetypeStorage.Initialize();
@@ -70,18 +69,5 @@ namespace NSprites
             // combine handles from all render archetypes we have updated
             Dependency = JobHandle.CombineDependencies(renderArchetypeHandles);
         }
-
-#region support methods
-        /// <summary>Returns array with all default components for rendering entities including types marked with <see cref="DisableRenderingComponent"/> attribute</summary>
-        private NativeArray<ComponentType> GetDefaultComponentTypes(in Allocator allocator = Allocator.Temp)
-        {
-            var disableRenderingComponentTypes = new NativeArray<ComponentType>(DisableRenderingComponent.GetTypes().ToArray(), Allocator.Persistent);
-            var defaultComponents = new NativeArray<ComponentType>(disableRenderingComponentTypes.Length + 1, allocator);
-            NativeArray<ComponentType>.Copy(disableRenderingComponentTypes, 0, defaultComponents, 0, disableRenderingComponentTypes.Length);
-            defaultComponents[defaultComponents.Length - 1] = ComponentType.ReadOnly<SpriteRenderID>();
-            disableRenderingComponentTypes.Dispose();
-            return defaultComponents;
-        }
-#endregion
     }
 }

--- a/Rendering/Systems/SpriteRenderingSystem.cs
+++ b/Rendering/Systems/SpriteRenderingSystem.cs
@@ -38,7 +38,7 @@ namespace NSprites
         }
         protected override void OnUpdate()
         {
-            var renderArchetypeStorage = EntityManager.GetComponentObject<RenderArchetypeStorage>(SystemHandle);
+            var renderArchetypeStorage = SystemAPI.ManagedAPI.GetComponent<RenderArchetypeStorage>(SystemHandle);
 #if UNITY_EDITOR
             if (!Application.isPlaying && renderArchetypeStorage._quad == null)
                 renderArchetypeStorage._quad = NSpritesUtils.ConstructQuad();
@@ -47,9 +47,9 @@ namespace NSprites
 #if !NSPRITES_REACTIVE_DISABLE || !NSPRITES_STATIC_DISABLE
             var state = renderArchetypeStorage._state;
             state.lastSystemVersion = LastSystemVersion;
-            state.propertyPointer_CTH_RW = GetComponentTypeHandle<PropertyPointer>(false);
-            state.propertyPointerChunk_CTH_RW = GetComponentTypeHandle<PropertyPointerChunk>(false);
-            state.propertyPointerChunk_CTH_RO = GetComponentTypeHandle<PropertyPointerChunk>(true);
+            state.propertyPointer_CTH_RW = SystemAPI.GetComponentTypeHandle<PropertyPointer>(false);
+            state.propertyPointerChunk_CTH_RW = SystemAPI.GetComponentTypeHandle<PropertyPointerChunk>(false);
+            state.propertyPointerChunk_CTH_RO = SystemAPI.GetComponentTypeHandle<PropertyPointerChunk>(true);
 #endif
             state.inputDeps = Dependency;
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "com.tonymax.nsprites",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "displayName": "NSprites",
-  "description": "DOTS sprite rendering system. Uses GPU instancing with compute buffers to draw entities as sprites.",
+  "description": "Entities sprite rendering system. Uses GPU instancing with compute buffers to draw entities as sprites.",
   "unity": "2022.2",
   "dependencies": {
     "com.unity.entities": "1.0.0-pre.15"


### PR DESCRIPTION
Changes:
From now all `SpriteRenderingSystem` data lives on managed system component as recommends in [docs](https://docs.unity3d.com/Packages/com.unity.entities@1.0/manual/systems-data.html). Also system now implemented as `struct` with `ISystem` instead of `SystemBase`.

How to migrate:
* All calls to `SpriteRenderingSystem` API should be replaced with accessing to `RenderArchetypeStorage` singleton. Registration code example:
```csharp
// registrate render with ID, Material, capacity data and set of proaperties
if (!SystemAPI.ManagedAPI.TryGetSingleton<RenderArchetypeStorage>(out var renderArchetypeStorage))
    return;
// don't registrate same renderID
renderArchetypeStorage.RegisterRender
(
    renderID,
    material,   // material with [Enable GPU Instancing] enabled and shader supporting instancing
    null,       // override for MaterialPropertyBlock if needed
    128,        // initial ComputeBuffers capacity
    128,        // minimal capacity step for ComputeBuffers
    "_pos2D",   // world 2D position property
    "_color"    // color property
);
```
* Any accessing to `SpriteRenderingSystem` if it still needed should happened with 1.0 unmanaged system accessing API.

Motivaton:
This update brings breaking changes but such changes pushes codebase closer to latest Entities API, so now client can expect working with data in recommened way.