### PR TITLE
fix Entities menu priority

### DIFF
--- a/Rendering/Editor/NSpritesWindow.cs
+++ b/Rendering/Editor/NSpritesWindow.cs
@@ -10,7 +10,7 @@ namespace NSprites
 {
     public class NSpritesWindow : EditorWindow
     {
-        [MenuItem("Window/Entities/NSprites")]
+        [MenuItem("Window/Entities/NSprites", false, 3005)]
         public static void OpenWindow()
         {
             var window = GetWindow<NSpritesWindow>();


### PR DESCRIPTION
fixed the project menu Window/Entities/NSprites and Unity Entities project menu Window/Entities display conflict that caused it not to show.